### PR TITLE
fix: vms can not startup automaticly

### DIFF
--- a/debian/phpvirtualbox-machines@.service
+++ b/debian/phpvirtualbox-machines@.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=PhpVirtualBox - start and save machines on boot and shutdown for user %I
+After=virtualbox.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
virtualbox.service checks environments and loads some kernel modules. Without these modules phpvirtualbox-manage-vms will fail to start, because the output of command `VBoxManage list vms` will be incorrect.